### PR TITLE
Support non-promise return values from execute

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const createLocalInterface = (graphql, schema, {rootValue = null, context = null
                 return Promise.reject(err)
             }
 
-            return result.then(data => {
+            return Promise.resolve(result).then(data => {
                 debug(`${operationName} (${(new Date() - start)}ms)`)
                 return data
             })

--- a/tests/index.js
+++ b/tests/index.js
@@ -3,12 +3,18 @@ const {createLocalInterface} = require('..')
 const test = createGroup()
 
 
-const fakeGraphql = {execute: () => Promise.resolve({foo: 'bar'})}
 const fakeSchema = {}
 
 test('it doesn\'t blow up for the most basic usage', () => {
+    const fakeGraphql = {execute: () => Promise.resolve({foo: 'bar'})}
     const iface = createLocalInterface(fakeGraphql, fakeSchema)
     const result = iface.query({})
     return assert.eventually.deepEqual(result, {foo: 'bar'})
 })
 
+test('it doesn\'t blow up for non-promise values', () => {
+    const fakeGraphql = {execute: () => ({foo: 'bar'})}
+    const iface = createLocalInterface(fakeGraphql, fakeSchema)
+    const result = iface.query({})
+    return assert.eventually.deepEqual(result, {foo: 'bar'})
+})


### PR DESCRIPTION
graphql@^0.12 introduced a breaking change (graphql/graphql-js#1115) 
which means `execute` is no longer guaranteed to return a Promise. The 
recommended usage is to always `Promise.resolve()` the result of `execute()`.